### PR TITLE
Add helper function to fetch frequency plans

### DIFF
--- a/account/frequency_plans.go
+++ b/account/frequency_plans.go
@@ -1,0 +1,27 @@
+// Copyright © 2016 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+package account
+
+import (
+	"github.com/TheThingsNetwork/go-account-lib/auth"
+	"github.com/TheThingsNetwork/go-account-lib/util"
+)
+
+// FrequencyPlans
+func FrequencyPlans(server string) (map[string]FrequencyPlan, error) {
+
+	var plans map[string]FrequencyPlan
+	err := util.GET(server, auth.Public, "/frequency-plans", &plans)
+	if err != nil {
+		return nil, err
+	}
+
+	// fill in the names
+	for key, plan := range plans {
+		plan.Name = key
+		plans[key] = plan
+	}
+
+	return plans, nil
+}

--- a/account/types.go
+++ b/account/types.go
@@ -78,3 +78,9 @@ type Location struct {
 	Longitude float64 `json:"lng"`
 	Latitude  float64 `json:"lat"`
 }
+
+type FrequencyPlan struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	URL         string `json:"url"`
+}


### PR DESCRIPTION
Makes this possible:
```go
plan, err := account.FrequencyPlans("https://staging.account.thethingsnetwork.org" )
```