### PR TITLE
Add WithFormat helpers for caches that write to disk

### DIFF
--- a/cache/file_cache.go
+++ b/cache/file_cache.go
@@ -16,26 +16,28 @@ type fileCache struct {
 	nameFn  func(string) string
 }
 
-// defaultFilename is the default filename generator
-func defaultFilename(key string) string {
-	return fmt.Sprintf("ttn-%s.data", key)
-}
+const defaultFormat = "ttn-%s.data"
 
 // FileCache returns a cache that stores keys on filesystem
 func FileCache(dirname string) Cache {
-	return &fileCache{
-		dirname: dirname,
-		nameFn:  defaultFilename,
-	}
+	return FileCacheWithFormat(dirname, defaultFormat)
 }
 
-// FileCacheWithNameFn creates a FileCache that has a custom way to generate
+// FileCacheWithNameFn creates a FileCache that has a custom function to generate
 // filenames
 func FileCacheWithNameFn(dirname string, filename func(string) string) Cache {
 	return &fileCache{
 		dirname: dirname,
 		nameFn:  filename,
 	}
+}
+
+// FileCacheWithFormat creates a FileCache that uses a format string to generate
+// filenames
+func FileCacheWithFormat(dirname string, format string) Cache {
+	return FileCacheWithNameFn(dirname, func(key string) string {
+		return fmt.Sprintf(format, key)
+	})
 }
 
 // filename creates the full filename for key based on configuration

--- a/cache/file_cache_test.go
+++ b/cache/file_cache_test.go
@@ -66,4 +66,8 @@ func TestFileCacheName(t *testing.T) {
 	name = fcache.filename("foo")
 	a.So(name, ShouldEqual, path.Join(dir, "bar"))
 
+	cache = FileCacheWithFormat(dir, "%s-foo")
+	fcache = cache.(*fileCache)
+	name = fcache.filename("foo")
+	a.So(name, ShouldEqual, path.Join(dir, "foo-foo"))
 }

--- a/cache/writetrough_cache.go
+++ b/cache/writetrough_cache.go
@@ -27,6 +27,15 @@ func WriteTroughCacheWithNameFn(dirname string, fn func(string) string) Cache {
 	}
 }
 
+// WriteTroughCacheWithFormat creates a cache that stores keys in memory
+// and uses disk as fallback and that generates filenames based on the format
+func WriteTroughCacheWithFormat(dirname, format string) Cache {
+	return &writeTroughCache{
+		memory: MemoryCache(),
+		file:   FileCacheWithFormat(dirname, format),
+	}
+}
+
 // Get gets the data from memory, and tries to read from disk
 // if not there, caching the result
 func (c *writeTroughCache) Get(key string) ([]byte, error) {

--- a/tokens/file_store.go
+++ b/tokens/file_store.go
@@ -32,6 +32,14 @@ func FileStoreWithNameFn(dirname string, nameFn func(string) string) TokenStore 
 	}
 }
 
+// FileStoreWithFormat creates a filestore that stores tokens in the
+// specified directory under with a custom filename
+func FileStoreWithFormat(dirname, format string) TokenStore {
+	return &fileStore{
+		cache: cache.FileCacheWithFormat(dirname, format),
+	}
+}
+
 // key creates a key for storing a token and scope by md5 hashing
 // the pair
 func (s *fileStore) key(parent, scope string) string {


### PR DESCRIPTION
Allows users of `FileCache` to specify the format of the filename based on key. This is simpler than using a function and is usually what we want.