### PR TITLE
Feature/deprecate

### DIFF
--- a/account/account.go
+++ b/account/account.go
@@ -4,56 +4,69 @@
 package account
 
 import (
+	"os"
+
 	"github.com/TheThingsNetwork/go-account-lib/auth"
 	"github.com/TheThingsNetwork/go-account-lib/tokens"
+	"github.com/TheThingsNetwork/go-utils/handlers/cli"
+	"github.com/apex/log"
 )
 
 // Account is a client to an account server
 type Account struct {
 	server string
 	auth   auth.Strategy
+	ctx    log.Interface
 }
 
-// New creates a new account client that will use the
-// accessToken to make requests to the specified account server
-func New(server, accessToken string) *Account {
+// New creates a new account that will use no authentication
+func New(server string) *Account {
 	return &Account{
 		server: server,
-		auth:   auth.AccessToken(accessToken),
+		auth:   auth.Public,
+		ctx: &log.Logger{
+			Handler: cli.New(os.Stdout),
+		},
 	}
+}
+
+// WithLogger sets the logger that the account will use to log warnings
+func (a *Account) WithLogger(logger log.Interface) *Account {
+	a.ctx = logger
+	return a
+}
+
+// WithAuth sets the authentication strategy the account will use
+func (a *Account) WithAuth(strategy auth.Strategy) *Account {
+	a.auth = strategy
+	return a
+}
+
+// NewWithAccessToken creates a new account client that will use the
+// accessToken to make requests to the specified account server
+func NewWithAccessToken(server, accessToken string) *Account {
+	return New(server).WithAuth(auth.AccessToken(accessToken))
 }
 
 // NewWithManager creates a new account client that will use the
 // accessToken to make requests to the specified account server
 // and the manager to request new tokens for different scopes
 func NewWithManager(server, accessToken string, manager tokens.Manager) *Account {
-	return &Account{
-		server: server,
-		auth:   auth.AccessTokenWithManager(accessToken, manager),
-	}
+	return New(server).WithAuth(auth.AccessTokenWithManager(accessToken, manager))
 }
 
 // NewWithKey creates an account client that uses an accessKey to
 // authenticate
 func NewWithKey(server, accessKey string) *Account {
-	return &Account{
-		server: server,
-		auth:   auth.AccessKey(accessKey),
-	}
+	return New(server).WithAuth(auth.AccessKey(accessKey))
 }
 
 // NewWithBasicAuth creates an account client that uses basic authentication
 func NewWithBasicAuth(server, username, password string) *Account {
-	return &Account{
-		server: server,
-		auth:   auth.BasicAuth(username, password),
-	}
+	return New(server).WithAuth(auth.BasicAuth(username, password))
 }
 
 // NewWithPublic creates an account client that does not use authentication
 func NewWithPublic(server string) *Account {
-	return &Account{
-		server: server,
-		auth:   auth.Public,
-	}
+	return New(server).WithAuth(auth.Public)
 }

--- a/account/frequency_plans.go
+++ b/account/frequency_plans.go
@@ -3,16 +3,12 @@
 
 package account
 
-import (
-	"github.com/TheThingsNetwork/go-account-lib/auth"
-	"github.com/TheThingsNetwork/go-account-lib/util"
-)
+import "github.com/TheThingsNetwork/go-account-lib/auth"
 
-// FrequencyPlans
-func FrequencyPlans(server string) (map[string]FrequencyPlan, error) {
-
+// FrequencyPlans returns the frequency plans the account server supports
+func (a *Account) FrequencyPlans() (map[string]FrequencyPlan, error) {
 	var plans map[string]FrequencyPlan
-	err := util.GET(server, auth.Public, "/frequency-plans", &plans)
+	err := a.get(auth.Public, "/frequency-plans", &plans)
 	if err != nil {
 		return nil, err
 	}

--- a/account/request.go
+++ b/account/request.go
@@ -9,21 +9,21 @@ import (
 )
 
 func (a *Account) get(strategy auth.Strategy, URI string, res interface{}) error {
-	return util.GET(a.server, strategy, URI, res)
+	return util.GET(a.ctx, a.server, strategy, URI, res)
 }
 
 func (a *Account) put(strategy auth.Strategy, URI string, body, res interface{}) error {
-	return util.PUT(a.server, strategy, URI, body, res)
+	return util.PUT(a.ctx, a.server, strategy, URI, body, res)
 }
 
 func (a *Account) post(strategy auth.Strategy, URI string, body, res interface{}) error {
-	return util.POST(a.server, strategy, URI, body, res)
+	return util.POST(a.ctx, a.server, strategy, URI, body, res)
 }
 
 func (a *Account) patch(strategy auth.Strategy, URI string, body, res interface{}) error {
-	return util.PATCH(a.server, strategy, URI, body, res)
+	return util.PATCH(a.ctx, a.server, strategy, URI, body, res)
 }
 
 func (a *Account) del(strategy auth.Strategy, URI string) error {
-	return util.DELETE(a.server, strategy, URI)
+	return util.DELETE(a.ctx, a.server, strategy, URI)
 }

--- a/account/users.go
+++ b/account/users.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	"github.com/TheThingsNetwork/go-account-lib/auth"
-	"github.com/TheThingsNetwork/go-account-lib/util"
 )
 
 type registerUserReq struct {
@@ -16,16 +15,15 @@ type registerUserReq struct {
 	Password string `json:"password"`
 }
 
-// RegisterUser registers a new user with the specified username, email and
-// password on the specified account server
-func RegisterUser(server, username, email, password string) error {
+// RegisterUser registers a user on the account server
+func (a *Account) RegisterUser(username, email, password string) error {
 	user := registerUserReq{
 		Username: username,
 		Email:    email,
 		Password: password,
 	}
 
-	err := util.POST(server, auth.Public, "/api/users", user, nil)
+	err := a.post(auth.Public, "/api/users", user, nil)
 	if err != nil {
 		return fmt.Errorf("Could not register user: %s", err)
 	}


### PR DESCRIPTION
Adds logging context to the `account.Account` type and uses it to log warnings from the server.

Also cleans up the constructor api for `account`. 

#### Breaking changes:

- `New(server, accessToken string) *Account` is now `NewWithAccessToken(server, accessToken string) *Account`
- `New(server) *Account` uses no authentication by default.
- `account.RegisterUser` is now a method on `Account`. To migrate:
```diff
- err := account.RegisterUser(server, username, email, password)
+ err := account.New(server).RegisterUser(username, email, password)
```

- `account.FrequencyPlans(server string)` is now a method on `Account`. To migrate:
```diff
- plans, err := account.RegisterUser(server, username, password)
+ plans, err := account.New(server).FrequencyPlans(username, password)
```

Added the `WithLogger` and `WithAuth` methods on `Account`, which can be chained:

```go
act := account.New(server).WithLogger(logger).WithAuth(auth.Public)
``` 