### PR TITLE
Rename Claims.Issuer to unbreak client code

### DIFF
--- a/claims/claims.go
+++ b/claims/claims.go
@@ -7,9 +7,9 @@ import jwt "github.com/dgrijalva/jwt-go"
 
 // TTNClaims is the interface all claims
 // that are issued by TTN need to adhere to
-type TTNClaims interface {
+type ClaimsWithIssuer interface {
 	jwt.Claims
-	Issuer() string
+	GetIssuer() string
 }
 
 // Claims represents all the claims an access token can have
@@ -30,7 +30,7 @@ type Claims struct {
 }
 
 // Issuer returns the issuer of the claims
-func (c *Claims) Issuer() string {
+func (c *Claims) GetIssuer() string {
 	return c.StandardClaims.Issuer
 }
 
@@ -43,6 +43,6 @@ type GatewayClaims struct {
 }
 
 // Issuer returns the issuer of the claims
-func (c *GatewayClaims) Issuer() string {
+func (c *GatewayClaims) GetIssuer() string {
 	return c.StandardClaims.Issuer
 }

--- a/claims/parse.go
+++ b/claims/parse.go
@@ -15,13 +15,13 @@ import (
 
 // fromToken parser a token given the tokenkey provider into the desired claims
 // structure
-func fromToken(provider tokenkey.Provider, token string, claims TTNClaims) error {
+func fromToken(provider tokenkey.Provider, token string, claims ClaimsWithIssuer) error {
 	parsed, err := jwt.ParseWithClaims(token, claims, func(token *jwt.Token) (interface{}, error) {
 		if provider == nil {
 			return nil, errors.New("No token provider configured")
 		}
 
-		k, err := provider.Get(claims.Issuer(), false)
+		k, err := provider.Get(claims.GetIssuer(), false)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Unbreak client code by renaming `Issuer` to `GetIssuer`