### PR TITLE
Feature/extra headers

### DIFF
--- a/account/account.go
+++ b/account/account.go
@@ -16,9 +16,10 @@ import (
 
 // Account is a client to an account server
 type Account struct {
-	server string
-	auth   auth.Strategy
-	ctx    log.Interface
+	server  string
+	auth    auth.Strategy
+	ctx     log.Interface
+	headers map[string]string
 }
 
 // New creates a new account that will use no authentication
@@ -29,6 +30,7 @@ func New(server string) *Account {
 		ctx: wrap.Wrap(&apex.Logger{
 			Handler: cli.New(os.Stdout),
 		}),
+		headers: map[string]string{},
 	}
 }
 
@@ -41,6 +43,12 @@ func (a *Account) WithLogger(logger log.Interface) *Account {
 // WithAuth sets the authentication strategy the account will use
 func (a *Account) WithAuth(strategy auth.Strategy) *Account {
 	a.auth = strategy
+	return a
+}
+
+// WithHeader adds the header to every request to the account server
+func (a *Account) WithHeader(name, value string) *Account {
+	a.headers[name] = value
 	return a
 }
 

--- a/account/request.go
+++ b/account/request.go
@@ -11,25 +11,25 @@ import (
 )
 
 func (a *Account) get(strategy auth.Strategy, URI string, res interface{}) error {
-	return util.GET(a.ctx, a.server, strategy, URI, res)
+	return util.GET(a.ctx, a.server, strategy, URI, a.headers, res)
 }
 
 func (a *Account) gets(strategy auth.Strategy, URI string) (io.ReadCloser, error) {
-	return util.GETBody(a.ctx, a.server, strategy, URI)
+	return util.GETBody(a.ctx, a.server, strategy, URI, a.headers)
 }
 
 func (a *Account) put(strategy auth.Strategy, URI string, body, res interface{}) error {
-	return util.PUT(a.ctx, a.server, strategy, URI, body, res)
+	return util.PUT(a.ctx, a.server, strategy, URI, a.headers, body, res)
 }
 
 func (a *Account) post(strategy auth.Strategy, URI string, body, res interface{}) error {
-	return util.POST(a.ctx, a.server, strategy, URI, body, res)
+	return util.POST(a.ctx, a.server, strategy, URI, a.headers, body, res)
 }
 
 func (a *Account) patch(strategy auth.Strategy, URI string, body, res interface{}) error {
-	return util.PATCH(a.ctx, a.server, strategy, URI, body, res)
+	return util.PATCH(a.ctx, a.server, strategy, URI, a.headers, body, res)
 }
 
 func (a *Account) del(strategy auth.Strategy, URI string) error {
-	return util.DELETE(a.ctx, a.server, strategy, URI)
+	return util.DELETE(a.ctx, a.server, strategy, URI, a.headers)
 }

--- a/oauth/gateway_key.go
+++ b/oauth/gateway_key.go
@@ -32,6 +32,6 @@ func (tok *tok) Token() *oauth2.Token {
 func (o *Config) ExchangeGatewayKeyForToken(gatewayID, gatewayKey string) (*oauth2.Token, error) {
 	strategy := auth.AccessKey(gatewayKey)
 	token := &tok{}
-	err := util.GET(log.Get(), o.Server, strategy, fmt.Sprintf("/api/v2/gateways/%s/token", gatewayID), token)
+	err := util.GET(log.Get(), o.Server, strategy, fmt.Sprintf("/api/v2/gateways/%s/token", gatewayID), o.Client.ExtraHeaders, token)
 	return token.Token(), err
 }

--- a/util/http_test.go
+++ b/util/http_test.go
@@ -25,6 +25,7 @@ var (
 	ctx           = wrap.Wrap(&apex.Logger{
 		Handler: cli.New(os.Stdout),
 	})
+	headers = map[string]string{}
 )
 
 type OKResp struct {
@@ -109,7 +110,7 @@ func TestGET(t *testing.T) {
 	defer server.Close()
 
 	var resp OKResp
-	err := GET(ctx, server.URL, tokenStrategy, url, &resp)
+	err := GET(ctx, server.URL, tokenStrategy, url, headers, &resp)
 	a.So(err, ShouldBeNil)
 	a.So(resp.OK, ShouldEqual, token)
 }
@@ -119,7 +120,7 @@ func TestGETDropResponse(t *testing.T) {
 	server := httptest.NewServer(OKHandler(a, "GET"))
 	defer server.Close()
 
-	err := GET(ctx, server.URL, tokenStrategy, url, nil)
+	err := GET(ctx, server.URL, tokenStrategy, url, headers, nil)
 	a.So(err, ShouldBeNil)
 }
 
@@ -129,7 +130,7 @@ func TestGETIllegalResponse(t *testing.T) {
 	defer server.Close()
 
 	var resp FooResp
-	err := GET(ctx, server.URL, tokenStrategy, url, &resp)
+	err := GET(ctx, server.URL, tokenStrategy, url, headers, &resp)
 	a.So(err, ShouldNotBeNil)
 }
 
@@ -139,7 +140,7 @@ func TestGETIllegalResponseIgnore(t *testing.T) {
 	defer server.Close()
 
 	var resp OKResp
-	err := GET(ctx, server.URL, tokenStrategy, url, &resp)
+	err := GET(ctx, server.URL, tokenStrategy, url, headers, &resp)
 	a.So(err, ShouldBeNil)
 }
 
@@ -149,7 +150,7 @@ func TestGETRedirect(t *testing.T) {
 	defer server.Close()
 
 	var resp OKResp
-	err := GET(ctx, server.URL, tokenStrategy, url, &resp)
+	err := GET(ctx, server.URL, tokenStrategy, url, headers, &resp)
 	a.So(err, ShouldBeNil)
 }
 
@@ -162,7 +163,7 @@ func TestPUT(t *testing.T) {
 	body := FooResp{
 		Foo: token,
 	}
-	err := PUT(ctx, server.URL, tokenStrategy, url, body, &resp)
+	err := PUT(ctx, server.URL, tokenStrategy, url, headers, body, &resp)
 	a.So(err, ShouldBeNil)
 	a.So(resp.Foo, ShouldEqual, body.Foo)
 }
@@ -174,7 +175,7 @@ func TestPUTIllegalRequest(t *testing.T) {
 
 	var resp FooResp
 	body := FooResp{}
-	err := PUT(ctx, server.URL, tokenStrategy, url, body, &resp)
+	err := PUT(ctx, server.URL, tokenStrategy, url, headers, body, &resp)
 	a.So(err, ShouldNotBeNil)
 }
 
@@ -184,7 +185,7 @@ func TestPUTIllegalResponse(t *testing.T) {
 	defer server.Close()
 
 	var resp FooResp
-	err := PUT(ctx, server.URL, tokenStrategy, url, nil, &resp)
+	err := PUT(ctx, server.URL, tokenStrategy, url, headers, nil, &resp)
 	a.So(err, ShouldNotBeNil)
 }
 
@@ -194,7 +195,7 @@ func TestPUTRedirect(t *testing.T) {
 	defer server.Close()
 
 	var resp FooResp
-	err := PUT(ctx, server.URL, tokenStrategy, url, nil, &resp)
+	err := PUT(ctx, server.URL, tokenStrategy, url, headers, nil, &resp)
 	a.So(err, ShouldBeNil)
 	a.So(resp.Foo, ShouldEqual, token)
 }
@@ -208,7 +209,7 @@ func TestPOST(t *testing.T) {
 	body := FooResp{
 		Foo: token,
 	}
-	err := POST(ctx, server.URL, tokenStrategy, url, body, &resp)
+	err := POST(ctx, server.URL, tokenStrategy, url, headers, body, &resp)
 	a.So(err, ShouldBeNil)
 	a.So(resp.Foo, ShouldEqual, body.Foo)
 }
@@ -220,7 +221,7 @@ func TestPOSTIllegalRequest(t *testing.T) {
 
 	var resp FooResp
 	body := FooResp{}
-	err := POST(ctx, server.URL, tokenStrategy, url, body, &resp)
+	err := POST(ctx, server.URL, tokenStrategy, url, headers, body, &resp)
 	a.So(err, ShouldNotBeNil)
 }
 
@@ -230,7 +231,7 @@ func TestPOSTIllegalResponse(t *testing.T) {
 	defer server.Close()
 
 	var resp FooResp
-	err := POST(ctx, server.URL, tokenStrategy, url, nil, &resp)
+	err := POST(ctx, server.URL, tokenStrategy, url, headers, nil, &resp)
 	a.So(err, ShouldNotBeNil)
 }
 
@@ -240,7 +241,7 @@ func TestPOSTRedirect(t *testing.T) {
 	defer server.Close()
 
 	var resp FooResp
-	err := POST(ctx, server.URL, tokenStrategy, url, nil, &resp)
+	err := POST(ctx, server.URL, tokenStrategy, url, headers, nil, &resp)
 	a.So(err, ShouldBeNil)
 	a.So(resp.Foo, ShouldEqual, token)
 }
@@ -250,7 +251,7 @@ func TestDELETE(t *testing.T) {
 	server := httptest.NewServer(OKHandler(a, "DELETE"))
 	defer server.Close()
 
-	err := DELETE(ctx, server.URL, tokenStrategy, url)
+	err := DELETE(ctx, server.URL, tokenStrategy, url, headers)
 	a.So(err, ShouldBeNil)
 }
 
@@ -259,7 +260,7 @@ func TestDELETERedirect(t *testing.T) {
 	server := httptest.NewServer(RedirectHandler(a, "DELETE"))
 	defer server.Close()
 
-	err := DELETE(ctx, server.URL, tokenStrategy, url)
+	err := DELETE(ctx, server.URL, tokenStrategy, url, headers)
 	a.So(err, ShouldBeNil)
 }
 
@@ -268,7 +269,7 @@ func TestDeprecated(t *testing.T) {
 	server := httptest.NewServer(DeprecatedHandler(a, "GET"))
 	defer server.Close()
 
-	err := GET(ctx, server.URL, tokenStrategy, url, nil)
+	err := GET(ctx, server.URL, tokenStrategy, url, headers, nil)
 	a.So(err, ShouldBeNil)
 }
 
@@ -277,6 +278,6 @@ func TestNilCtx(t *testing.T) {
 	server := httptest.NewServer(DeprecatedHandler(a, "GET"))
 	defer server.Close()
 
-	err := GET(nil, server.URL, tokenStrategy, url, nil)
+	err := GET(nil, server.URL, tokenStrategy, url, headers, nil)
 	a.So(err, ShouldBeNil)
 }

--- a/util/roundtripper.go
+++ b/util/roundtripper.go
@@ -5,6 +5,7 @@ package util
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/TheThingsNetwork/go-utils/log"
 )
@@ -25,7 +26,11 @@ func NewRoundTripper(ctx log.Interface, headers map[string]string) *RoundTripper
 
 func (t *RoundTripper) addHeaders(req *http.Request) {
 	for name, value := range t.headers {
-		req.Header.Set(name, value)
+		switch strings.ToLower(name) {
+		case "authorization":
+		default:
+			req.Header.Set(name, value)
+		}
 	}
 }
 

--- a/util/roundtripper.go
+++ b/util/roundtripper.go
@@ -1,0 +1,53 @@
+// Copyright © 2016 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+package util
+
+import (
+	"net/http"
+
+	"github.com/TheThingsNetwork/go-utils/log"
+)
+
+type RoundTripper struct {
+	ctx       log.Interface
+	transport http.RoundTripper
+	headers   map[string]string
+}
+
+func NewRoundTripper(ctx log.Interface, headers map[string]string) *RoundTripper {
+	return &RoundTripper{
+		ctx:       ctx,
+		transport: http.DefaultTransport,
+		headers:   headers,
+	}
+}
+
+func (t *RoundTripper) addHeaders(req *http.Request) {
+	for name, value := range t.headers {
+		req.Header.Set(name, value)
+	}
+}
+
+func (t *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.addHeaders(req)
+	res, err := t.transport.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// get server warnings
+	if warning := res.Header.Get("Warning"); warning != "" {
+		// Warning header has format: 123 - "Message"
+		code := warning[0:3]
+		message := warning[7 : len(warning)-1]
+		if t.ctx != nil {
+			t.ctx.WithFields(map[string]interface{}{
+				"code":    code,
+				"message": message,
+			}).Warn("Got server warning. Make sure the client is up to date.")
+		}
+	}
+
+	return res, nil
+}

--- a/util/roundtripper_test.go
+++ b/util/roundtripper_test.go
@@ -1,0 +1,64 @@
+package util
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	. "github.com/smartystreets/assertions"
+)
+
+const (
+	uri = "/foo"
+)
+
+func HeadersHandler(a *Assertion, method string, headers map[string]string) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		a.So(r.RequestURI, ShouldEqual, uri)
+		a.So(r.Method, ShouldEqual, method)
+
+		resp := struct{}{}
+
+		for name, val := range headers {
+			a.So(r.Header.Get(name), ShouldEqual, val)
+		}
+		w.WriteHeader(http.StatusOK)
+		encoder := json.NewEncoder(w)
+		encoder.Encode(&resp)
+	})
+}
+
+func TestGet(t *testing.T) {
+	a := New(t)
+
+	// nil headers
+	{
+		var headers map[string]string
+		client := &http.Client{
+			Transport: NewRoundTripper(nil, headers),
+		}
+		server := httptest.NewServer(HeadersHandler(a, "GET", headers))
+		defer server.Close()
+
+		_, err := client.Get(fmt.Sprintf("%s%s", server.URL, uri))
+		a.So(err, ShouldBeNil)
+	}
+
+	// nil headers
+	{
+		headers := map[string]string{
+			"Foo": "bar",
+		}
+
+		client := &http.Client{
+			Transport: NewRoundTripper(nil, headers),
+		}
+		server := httptest.NewServer(HeadersHandler(a, "GET", headers))
+		defer server.Close()
+
+		_, err := client.Get(fmt.Sprintf("%s%s", server.URL, uri))
+		a.So(err, ShouldBeNil)
+	}
+}


### PR DESCRIPTION
Allows `account.Account` and `oauth.Client` to set extra headers they want to use when talking to the account server, also moves logging warnings into the rountripper.