### PR TITLE
cache.memoryCache: use mutex

### DIFF
--- a/cache/memory_cache.go
+++ b/cache/memory_cache.go
@@ -3,9 +3,12 @@
 
 package cache
 
+import "sync"
+
 // memoryCache represents a cache that stores keys in memory
 type memoryCache struct {
 	cache map[string][]byte
+	sync.RWMutex
 }
 
 // MemoryCache returns a cache that stores keys in memory
@@ -17,6 +20,9 @@ func MemoryCache() Cache {
 
 // Get gets the data from memory if it exists
 func (c *memoryCache) Get(key string) ([]byte, error) {
+	c.RLock()
+	defer c.RUnlock()
+
 	cached, ok := c.cache[key]
 	if ok {
 		return cached, nil
@@ -27,6 +33,9 @@ func (c *memoryCache) Get(key string) ([]byte, error) {
 
 // Set saves the data to memory
 func (c *memoryCache) Set(key string, data []byte) error {
+	c.Lock()
+	defer c.Unlock()
+
 	c.cache[key] = data
 	return nil
 }


### PR DESCRIPTION
NOC production cluster starter constantly `panic`'ing on startup

here's an excerpt from the log:
```
noc_1     | fatal error: concurrent map read and map write
noc_1     | goroutine 1137 [running]:
noc_1     | runtime.throw(0xb06767, 0x21)
noc_1     | 	/usr/local/go/src/runtime/panic.go:566 +0x95 fp=0xc4213ab320 sp=0xc4213ab300
noc_1     | runtime.mapaccess2_faststr(0xa387a0, 0xc4202d1a10, 0xc4201d0400, 0xe, 0xa05380, 0x0)
noc_1     | 	/usr/local/go/src/runtime/hashmap_fast.go:306 +0x52b fp=0xc4213ab380 sp=0xc4213ab320
noc_1     | github.com/TheThingsIndustries/noc/vendor/github.com/TheThingsNetwork/go-account-lib/cache.(*memoryCache).Get(0xc420118488, 0xc4201d0400, 0xe, 0x0, 0x0, 0x0, 0x0, 0xc4213ab420)
noc_1     | 	/go/src/github.com/TheThingsIndustries/noc/vendor/github.com/TheThingsNetwork/go-account-lib/cache/memory_cache.go:20 +0x52 fp=0xc4213ab3c0 sp=0xc4213ab380
noc_1     | github.com/TheThingsIndustries/noc/vendor/github.com/TheThingsNetwork/go-account-lib/cache.(*writeTroughCache).Get(0xc4204265e0, 0xc4201d0400, 0xe, 0xc4201d0340, 0x42b29c, 0xc4213ab4b0, 0xc4213ab4b0, 0x0)
noc_1     | 	/go/src/github.com/TheThingsIndustries/noc/vendor/github.com/TheThingsNetwork/go-account-lib/cache/writetrough_cache.go:43 +0x4b fp=0xc4213ab428 sp=0xc4213ab3c0
noc_1     | github.com/TheThingsIndustries/noc/vendor/github.com/TheThingsNetwork/go-account-lib/tokenkey.(*httpProvider).Get(0xc420426620, 0xc4201d0400, 0xe, 0x42b200, 0xc4213ab530, 0xc4213ab530, 0x531bcd)
noc_1     | 	/go/src/github.com/TheThingsIndustries/noc/vendor/github.com/TheThingsNetwork/go-account-lib/tokenkey/http_provider.go:30 +0x58 fp=0xc4213ab4b0 sp=0xc4213ab428
noc_1     | github.com/TheThingsIndustries/noc/vendor/github.com/TheThingsNetwork/go-account-lib/claims.fromToken.func1(0xc4213550e0, 0x5, 0xe9f0c0, 0xc4201802a0, 0xc42136f701)
noc_1     | 	/go/src/github.com/TheThingsIndustries/noc/vendor/github.com/TheThingsNetwork/go-account-lib/claims/parse.go:24 +0x89 fp=0xc4213ab570 sp=0xc4213ab4b0
noc_1     | github.com/TheThingsIndustries/noc/vendor/github.com/dgrijalva/jwt-go.(*Parser).ParseWithClaims(0xc4213ab768, 0xc420f17000, 0x397, 0xe96fc0, 0xc42133bd50, 0xc4213945a0, 0x0, 0xc420503798, 0x40f42f)
noc_1     | 	/go/src/github.com/TheThingsIndustries/noc/vendor/github.com/dgrijalva/jwt-go/parser.go:97 +0x58f fp=0xc4213ab720 sp=0xc4213ab570
noc_1     | github.com/TheThingsIndustries/noc/vendor/github.com/dgrijalva/jwt-go.ParseWithClaims(0xc420f17000, 0x397, 0xe96fc0, 0xc42133bd50, 0xc4213945a0, 0xc420503800, 0x411d88, 0x70)
noc_1     | 	/go/src/github.com/TheThingsIndustries/noc/vendor/github.com/dgrijalva/jwt-go/token.go:93 +0x8f fp=0xc4213ab798 sp=0xc4213ab720
noc_1     | github.com/TheThingsIndustries/noc/vendor/github.com/TheThingsNetwork/go-account-lib/claims.fromToken(0xe9b140, 0xc420426620, 0xc420f17000, 0x397, 0xe9b100, 0xc42133bd50, 0x4, 0x0)
noc_1     | 	/go/src/github.com/TheThingsIndustries/noc/vendor/github.com/TheThingsNetwork/go-account-lib/claims/parse.go:46 +0xde fp=0xc4213ab800 sp=0xc4213ab798
noc_1     | github.com/TheThingsIndustries/noc/vendor/github.com/TheThingsNetwork/go-account-lib/claims.FromGatewayToken(0xe9b140, 0xc420426620, 0xc420f17000, 0x397, 0xc420503980, 0x40a4d4, 0xa8dea0)
noc_1     | 	/go/src/github.com/TheThingsIndustries/noc/vendor/github.com/TheThingsNetwork/go-account-lib/claims/parse_gateway.go:16 +0x9c fp=0xc4213ab868 sp=0xc4213ab800
```

This PR should fix the issue, by eliminating possible race conditions