### PR TITLE
Add Righter interfaces so Claims becomes mockable

### DIFF
--- a/claims/rights.go
+++ b/claims/rights.go
@@ -3,29 +3,6 @@
 
 package claims
 
-// AppRighter is the interface of everything that can hold rights to an app
-type AppRighter interface {
-	// AppRight checks wether or not the specified right is held on the app with the
-	// specified appID
-	AppRight(appID string, right string) bool
-}
-
-// GatewayRighter is the interface of everything that can hold rights to a
-// gateway
-type GatewayRighter interface {
-	// GatewayRight checks wether or not the specified right is held on the
-	// gateway with the specified gatewayID
-	GatewayRight(gatewayID string, right string) bool
-}
-
-// ComponentRighter is the interface of everything that can hold rights to a
-// component
-type ComponentRighter interface {
-	// ComponentRight checks wether or not the specified right is held on the
-	// gateway with the specified gatewayID
-	ComponentRight(gatewayID string, right string) bool
-}
-
 // AppRight checks if the token grants the specified right for
 // the app with the specified ID
 func (claims *Claims) AppRight(appID string, right string) bool {

--- a/claims/rights.go
+++ b/claims/rights.go
@@ -3,6 +3,29 @@
 
 package claims
 
+// AppRighter is the interface of everything that can hold rights to an app
+type AppRighter interface {
+	// AppRight checks wether or not the specified right is held on the app with the
+	// specified appID
+	AppRight(appID string, right string) bool
+}
+
+// GatewayRighter is the interface of everything that can hold rights to a
+// gateway
+type GatewayRighter interface {
+	// GatewayRight checks wether or not the specified right is held on the
+	// gateway with the specified gatewayID
+	GatewayRight(gatewayID string, right string) bool
+}
+
+// ComponentRighter is the interface of everything that can hold rights to a
+// component
+type ComponentRighter interface {
+	// ComponentRight checks wether or not the specified right is held on the
+	// gateway with the specified gatewayID
+	ComponentRight(gatewayID string, right string) bool
+}
+
 // AppRight checks if the token grants the specified right for
 // the app with the specified ID
 func (claims *Claims) AppRight(appID string, right string) bool {

--- a/rights/righter.go
+++ b/rights/righter.go
@@ -1,0 +1,27 @@
+// Copyright © 2016 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+package rights
+
+// AppRighter is the interface of everything that can hold rights to an app
+type AppRighter interface {
+	// AppRight checks wether or not the specified right is held on the app with the
+	// specified appID
+	AppRight(appID string, right string) bool
+}
+
+// GatewayRighter is the interface of everything that can hold rights to a
+// gateway
+type GatewayRighter interface {
+	// GatewayRight checks wether or not the specified right is held on the
+	// gateway with the specified gatewayID
+	GatewayRight(gatewayID string, right string) bool
+}
+
+// ComponentRighter is the interface of everything that can hold rights to a
+// component
+type ComponentRighter interface {
+	// ComponentRight checks wether or not the specified right is held on the
+	// gateway with the specified gatewayID
+	ComponentRight(gatewayID string, right string) bool
+}


### PR DESCRIPTION
Adds interface `AppRighter`, `GatewayRighter`, `ComponentRighter` interfaces for mocking.