### PR TITLE
Make right a seperate type

### DIFF
--- a/account/types.go
+++ b/account/types.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/TheThingsNetwork/go-account-lib/rights"
 	"github.com/TheThingsNetwork/ttn/core/types"
 	"golang.org/x/oauth2"
 )
@@ -23,12 +24,12 @@ type Application struct {
 
 // Collaborator is a user that has rights to a certain application
 type Collaborator struct {
-	Username string        `json:"username" valid:"required"`
-	Rights   []types.Right `json:"rights"   valid:"required"`
+	Username string         `json:"username" valid:"required"`
+	Rights   []rights.Right `json:"rights"   valid:"required"`
 }
 
 // HasRight checks if the collaborator has a specific right
-func (c *Collaborator) HasRight(right types.Right) bool {
+func (c *Collaborator) HasRight(right rights.Right) bool {
 	for _, r := range c.Rights {
 		if r == right {
 			return true
@@ -101,7 +102,7 @@ type Gateway struct {
 	Activated        bool           `json:"activated"`
 	FrequencyPlan    string         `json:"frequency_plan"`
 	FrequencyPlanURL string         `json:"frequency_plan_url"`
-	PublicRights     []types.Right  `json:"public_rights"`
+	PublicRights     []rights.Right `json:"public_rights"`
 	LocationPublic   bool           `json:"location_public"`
 	StatusPublic     bool           `json:"status_public"`
 	AutoUpdate       bool           `json:"auto_update"`

--- a/account/types_test.go
+++ b/account/types_test.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/TheThingsNetwork/ttn/core/types"
+	"github.com/TheThingsNetwork/go-account-lib/rights"
 	"github.com/smartystreets/assertions"
 )
 
@@ -15,13 +15,13 @@ func TestCollaboratorRights(t *testing.T) {
 	a := assertions.New(t)
 	c := Collaborator{
 		Username: "username",
-		Rights: []types.Right{
-			types.Right("right"),
+		Rights: []rights.Right{
+			rights.Right("right"),
 		},
 	}
 
-	a.So(c.HasRight(types.Right("right")), assertions.ShouldBeTrue)
-	a.So(c.HasRight(types.Right("foo")), assertions.ShouldBeFalse)
+	a.So(c.HasRight(rights.Right("right")), assertions.ShouldBeTrue)
+	a.So(c.HasRight(rights.Right("foo")), assertions.ShouldBeFalse)
 }
 
 func TestNameString(t *testing.T) {

--- a/claims/claims.go
+++ b/claims/claims.go
@@ -3,7 +3,10 @@
 
 package claims
 
-import jwt "github.com/dgrijalva/jwt-go"
+import (
+	"github.com/TheThingsNetwork/go-account-lib/rights"
+	jwt "github.com/dgrijalva/jwt-go"
+)
 
 // TTNClaims is the interface all claims
 // that are issued by TTN need to adhere to
@@ -15,14 +18,14 @@ type ClaimsWithIssuer interface {
 // Claims represents all the claims an access token can have
 type Claims struct {
 	jwt.StandardClaims
-	Client     string              `json:"client"`
-	Scope      []string            `json:"scope"`
-	Type       string              `json:"type,omitempty"`
-	Apps       map[string][]string `json:"apps,omitempty"`
-	Gateways   map[string][]string `json:"gateways,omitempty"`
-	Components map[string][]string `json:"components,omitempty"`
-	Username   string              `json:"username"`
-	Email      string              `json:"email"`
+	Client     string                    `json:"client"`
+	Scope      []string                  `json:"scope"`
+	Type       string                    `json:"type,omitempty"`
+	Apps       map[string][]rights.Right `json:"apps,omitempty"`
+	Gateways   map[string][]rights.Right `json:"gateways,omitempty"`
+	Components map[string][]rights.Right `json:"components,omitempty"`
+	Username   string                    `json:"username"`
+	Email      string                    `json:"email"`
 	Name       struct {
 		First string `json:"first"`
 		Last  string `json:"last"`

--- a/claims/claims_test.go
+++ b/claims/claims_test.go
@@ -3,10 +3,12 @@
 
 package claims
 
+import "github.com/TheThingsNetwork/go-account-lib/rights"
+
 const appID = "foo"
 const gatewayID = "foo"
 const componentID = "foo"
-const right = "settings"
+const right = rights.Right("settings")
 const otherRight = "delete"
 
 var none *Claims
@@ -14,8 +16,8 @@ var empty = Claims{}
 
 var withAppAccess = Claims{
 	Scope: []string{"apps:" + appID},
-	Apps: map[string][]string{
-		appID: []string{right},
+	Apps: map[string][]rights.Right{
+		appID: []rights.Right{right},
 	},
 }
 
@@ -24,15 +26,15 @@ var withAppsScope = Claims{
 }
 
 var appRightsButNoScope = Claims{
-	Apps: map[string][]string{
-		appID: []string{right},
+	Apps: map[string][]rights.Right{
+		appID: []rights.Right{right},
 	},
 }
 
 var withGatewayAccess = Claims{
 	Scope: []string{"gateways:" + gatewayID},
-	Gateways: map[string][]string{
-		gatewayID: []string{right},
+	Gateways: map[string][]rights.Right{
+		gatewayID: []rights.Right{right},
 	},
 }
 
@@ -41,15 +43,15 @@ var withGatewaysScope = Claims{
 }
 
 var gatewayRightsButNoScope = Claims{
-	Gateways: map[string][]string{
-		gatewayID: []string{right},
+	Gateways: map[string][]rights.Right{
+		gatewayID: []rights.Right{right},
 	},
 }
 
 var withComponentAccess = Claims{
 	Scope: []string{"components:" + componentID},
-	Components: map[string][]string{
-		componentID: []string{right},
+	Components: map[string][]rights.Right{
+		componentID: []rights.Right{right},
 	},
 }
 
@@ -58,7 +60,7 @@ var withComponentsScope = Claims{
 }
 
 var componentRightsButNoScope = Claims{
-	Components: map[string][]string{
-		componentID: []string{right},
+	Components: map[string][]rights.Right{
+		componentID: []rights.Right{right},
 	},
 }

--- a/claims/rights.go
+++ b/claims/rights.go
@@ -3,20 +3,22 @@
 
 package claims
 
+import "github.com/TheThingsNetwork/go-account-lib/rights"
+
 // AppRight checks if the token grants the specified right for
 // the app with the specified ID
-func (claims *Claims) AppRight(appID string, right string) bool {
-	return claims.AppAccess(appID) && contains(claims.Apps[appID], right)
+func (claims *Claims) AppRight(appID string, right rights.Right) bool {
+	return claims.AppAccess(appID) && containsRight(claims.Apps[appID], right)
 }
 
 // GatewayRight checks if the token grants the specified right for
 // the Gateway with the specified ID
-func (claims *Claims) GatewayRight(gatewayID string, right string) bool {
-	return claims.GatewayAccess(gatewayID) && contains(claims.Gateways[gatewayID], right)
+func (claims *Claims) GatewayRight(gatewayID string, right rights.Right) bool {
+	return claims.GatewayAccess(gatewayID) && containsRight(claims.Gateways[gatewayID], right)
 }
 
 // ComponentRight checks if the token grants the specified right for
 // the Component with the specified ID
-func (claims *Claims) ComponentRight(componentID string, right string) bool {
-	return claims.ComponentAccess(componentID) && contains(claims.Components[componentID], right)
+func (claims *Claims) ComponentRight(componentID string, right rights.Right) bool {
+	return claims.ComponentAccess(componentID) && containsRight(claims.Components[componentID], right)
 }

--- a/claims/util.go
+++ b/claims/util.go
@@ -3,8 +3,19 @@
 
 package claims
 
+import "github.com/TheThingsNetwork/go-account-lib/rights"
+
 // contains checks for membership of a string in a stringmap
 func contains(slice []string, el string) bool {
+	for _, e := range slice {
+		if e == el {
+			return true
+		}
+	}
+	return false
+}
+
+func containsRight(slice []rights.Right, el rights.Right) bool {
 	for _, e := range slice {
 		if e == el {
 			return true

--- a/rights/righter.go
+++ b/rights/righter.go
@@ -7,7 +7,7 @@ package rights
 type AppRighter interface {
 	// AppRight checks wether or not the specified right is held on the app with the
 	// specified appID
-	AppRight(appID string, right string) bool
+	AppRight(appID string, right Right) bool
 }
 
 // GatewayRighter is the interface of everything that can hold rights to a
@@ -15,7 +15,7 @@ type AppRighter interface {
 type GatewayRighter interface {
 	// GatewayRight checks wether or not the specified right is held on the
 	// gateway with the specified gatewayID
-	GatewayRight(gatewayID string, right string) bool
+	GatewayRight(gatewayID string, right Right) bool
 }
 
 // ComponentRighter is the interface of everything that can hold rights to a
@@ -23,5 +23,5 @@ type GatewayRighter interface {
 type ComponentRighter interface {
 	// ComponentRight checks wether or not the specified right is held on the
 	// gateway with the specified gatewayID
-	ComponentRight(gatewayID string, right string) bool
+	ComponentRight(gatewayID string, right Right) bool
 }

--- a/rights/rights.go
+++ b/rights/rights.go
@@ -3,49 +3,51 @@
 
 package rights
 
+type Right string
+
 const (
 	// AppSettings is the right to read and write access to the settings, devices and access keys of the application
-	AppSettings = "settings"
+	AppSettings Right = "settings"
 
 	// AppCollaborators is the right to edit and modify collaborators of the application
-	AppCollaborators = "collaborators"
+	AppCollaborators Right = "collaborators"
 
 	// is the right to delete the application
-	AppDelete = "delete"
+	AppDelete Right = "delete"
 
 	// ReadUplink is the right to view messages sent by devices of the application
-	ReadUplink = "messages:up:r"
+	ReadUplink Right = "messages:up:r"
 
 	// WriteUplink is the right to send messages to the application
-	WriteUplink = "messages:up:w"
+	WriteUplink Right = "messages:up:w"
 
 	// WriteDownlink is the right to send messages to devices of the application
-	WriteDownlink = "messages:down:w"
+	WriteDownlink Right = "messages:down:w"
 
 	// evices is the right to list, edit and remove devices for the application on a handler
-	Devices = "devices"
+	Devices Right = "devices"
 
 	// GatewaySettings is the right to read and write access to the gateway settings
-	GatewaySettings = "gateway:settings"
+	GatewaySettings Right = "gateway:settings"
 
 	// GatewayCollaborators is the right to edit the gateway collaborators
-	GatewayCollaborators = "gateway:collaborators"
+	GatewayCollaborators Right = "gateway:collaborators"
 
 	// GatewayDelete is the right to delete a gatweay
-	GatewayDelete = "gateway:delete"
+	GatewayDelete Right = "gateway:delete"
 
 	// GatewayLocation is the right to view the exact location of the gateway, otherwise only approximate location will be shown
-	GatewayLocation = "gateway:location"
+	GatewayLocation Right = "gateway:location"
 
 	// GatewayStatus is the right to view the gateway status and metrics about the gateway
-	GatewayStatus = "gateway:status"
+	GatewayStatus Right = "gateway:status"
 
 	// GatewayOwner is the right to view the owner of the gateway
-	GatewayOwner = "gateway:owner"
+	GatewayOwner Right = "gateway:owner"
 
 	// ComponentSettings is the right to read and write access to the settings and access key of a network component
-	ComponentSettings = "component:settings"
+	ComponentSettings Right = "component:settings"
 
 	// ComponentDelete is the right to delete the network component
-	ComponentDelete = "component:delete"
+	ComponentDelete Right = "component:delete"
 )


### PR DESCRIPTION
Makes rights a separate type to avoid overloading `string`.