### PR TITLE
Add utility to get the status code of an error

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -9,11 +9,13 @@ import (
 
 // StatusCode gets the status code from an error, defaulting to 500
 func StatusCode(err error) int {
-	switch err.(type) {
+	switch t := err.(type) {
 	case util.HTTPError:
-		return err.Code
-	case oauth.Error:
-		return err.Code
+		return t.Code
+	case *util.HTTPError:
+		return t.Code
+	case *oauth.Error:
+		return t.Code
 	default:
 		return http.StatusInternalServerError
 	}

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -7,7 +7,7 @@ import (
 	"github.com/TheThingsNetwork/go-account-lib/util"
 )
 
-// Get a status code from an error
+// StatusCode gets the status code from an error, defaulting to 500
 func StatusCode(err error) int {
 	switch err.(type) {
 	case util.HTTPError:

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,0 +1,20 @@
+package errors
+
+import (
+	"net/http"
+
+	"github.com/TheThingsNetwork/go-account-lib/oauth"
+	"github.com/TheThingsNetwork/go-account-lib/util"
+)
+
+// Get a status code from an error
+func StatusCode(err error) int {
+	switch err.(type) {
+	case util.HTTPError:
+		return err.Code
+	case oauth.Error:
+		return err.Code
+	default:
+		return http.StatusInternalServerError
+	}
+}

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -1,0 +1,45 @@
+// Copyright © 2016 The Things Network
+// Use of this source code is governed by the MIT license that can be found in the LICENSE file.
+
+package errors
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/TheThingsNetwork/go-account-lib/oauth"
+	"github.com/TheThingsNetwork/go-account-lib/util"
+	. "github.com/smartystreets/assertions"
+)
+
+func TestStatusCode(t *testing.T) {
+	a := New(t)
+
+	{
+		code := StatusCode(&util.HTTPError{
+			Code: 403,
+		})
+		a.So(code, ShouldEqual, 403)
+	}
+
+	{
+		code := StatusCode(util.HTTPError{
+			Code: 401,
+		})
+
+		a.So(code, ShouldEqual, 401)
+	}
+
+	{
+		code := StatusCode(&oauth.Error{
+			Code: 400,
+		})
+
+		a.So(code, ShouldEqual, 400)
+	}
+
+	{
+		code := StatusCode(fmt.Errorf("ok"))
+		a.So(code, ShouldEqual, 500)
+	}
+}


### PR DESCRIPTION
Resolves #51 but in a slightly different. way than proposed.

Because the error messages are variant, constants could not be used. Instead, this provides a utility
which can get the HTTP status code from an error:

```
if errors.StatusCode(err) == http.StatusUnauthorized {
  // unauthorized
}
```