### PR TITLE
Feature/handler token exchange

### DIFF
--- a/account/applications.go
+++ b/account/applications.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"io"
 
+	"golang.org/x/oauth2"
+
 	"github.com/TheThingsNetwork/go-account-lib/scope"
 	"github.com/TheThingsNetwork/ttn/core/types"
 )
@@ -191,4 +193,31 @@ func (a *Account) AppCollaborators(appID string) ([]Collaborator, error) {
 	}
 
 	return collaborators, nil
+}
+
+type exchangeReq struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+type exchangeRes struct {
+	AccessToken string `json:"access_token"`
+	ExpiresIn   int    `json:"expires_in"`
+}
+
+// ExchangeAppKeyForToken exchanges an app ID and app Key for an app token
+func (a *Account) ExchangeAppKeyForToken(appID, accessKey string) (*oauth2.Token, error) {
+	req := exchangeReq{
+		Username: appID,
+		Password: accessKey,
+	}
+
+	var res tokenRes
+
+	err := a.post(a.auth, "/api/v2/applications/token", &req, &res)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Token(), nil
 }

--- a/account/gateways.go
+++ b/account/gateways.go
@@ -73,7 +73,7 @@ func (a *Account) StreamGateways() (*GatewayStream, error) {
 
 type gatewayRes struct {
 	Gateway
-	GWToken gatewayToken `json:"token"`
+	GWToken tokenRes `json:"token"`
 }
 
 func (r *gatewayRes) ToGateway() Gateway {
@@ -152,7 +152,7 @@ func (a *Account) RegisterGateway(gatewayID string, frequencyPlan string, opts G
 
 // GetGatewayToken gets the gateway token
 func (a *Account) GetGatewayToken(gatewayID string) (*oauth2.Token, error) {
-	token := new(gatewayToken)
+	token := new(tokenRes)
 	err := a.get(a.auth.WithScope(scope.Gateway(gatewayID)), fmt.Sprintf("/api/v2/gateways/%s/token", gatewayID), token)
 	if err != nil {
 		return nil, err

--- a/account/types.go
+++ b/account/types.go
@@ -62,13 +62,13 @@ func (n *Name) String() string {
 	return n.First + " " + n.Last
 }
 
-type gatewayToken struct {
+type tokenRes struct {
 	AccessToken string `json:"access_token"`
 	ExpiresIn   uint64 `json:"expires_in"`
 }
 
 // Token transfroms a gateway token to oauth token with correct expiry
-func (token *gatewayToken) Token() *oauth2.Token {
+func (token *tokenRes) Token() *oauth2.Token {
 	if token == nil {
 		return nil
 	}


### PR DESCRIPTION
Adds `ExchangeAppKeyForToken` to `account.Account` so it can be used with handler tokens.